### PR TITLE
add code coverage pipeline and artisan cmd

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -1,0 +1,37 @@
+name: Laravel
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  laravel-tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
+      with:
+        php-version: '8.1'
+    - uses: actions/checkout@v2
+    - name: Copy .env
+      run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+    - name: Install Dependencies
+      run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+    - name: Generate key
+      run: php artisan key:generate
+    - name: Directory Permissions
+      run: chmod -R 777 storage bootstrap/cache
+    - name: Create Database
+      run: |
+        mkdir -p database
+        touch database/database.sqlite
+    - name: Execute tests (Unit and Feature tests) via PHPUnit
+      env:
+        DB_CONNECTION: sqlite
+        DB_DATABASE: database/database.sqlite
+      run: vendor/bin/phpunit --coverage-xml ./coverage/
+    - name: Check code coverage
+      run: php artisan test:coverage 60

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ npm-debug.log
 yarn-error.log
 /.idea
 /.vscode
+/coverage

--- a/app/Console/Commands/CheckCoverage.php
+++ b/app/Console/Commands/CheckCoverage.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Exceptions\CoverageException;
+use Illuminate\Console\Command;
+
+class CheckCoverage extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'test:coverage {threshold=80}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Check code coverage XML report based on threshold';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $threshold = $this->argument('threshold');
+
+        try {
+            $xml = simplexml_load_file(__DIR__ . '/../../../coverage/index.xml');
+            $percentage = (float)$xml->project->directory->totals->lines['percent'];
+            echo "line coverage: $percentage\n";
+            echo "threshold: $threshold\n";
+
+            if (ceil($percentage) < $threshold) {
+                throw new CoverageException($threshold);
+            }
+
+            return 0;
+        } catch (CoverageException $e) {
+            echo "{$e->getCoverageMessage($threshold)}\n";
+
+            return 1;
+        } catch (\Throwable $e) {
+            if (str_contains($e->getMessage(), 'simplexml_load_file')) {
+                echo "problem loading coverage file\n";
+            } else {
+                echo "{$e->getMessage()}\n";
+            }
+
+            return 1;
+        }
+    }
+}

--- a/app/Exceptions/CoverageException.php
+++ b/app/Exceptions/CoverageException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class CoverageException extends Exception
+{
+    private const MSG = 'Code coverage is lower than expected threshold of {threshold}';
+
+    public final function getCoverageMessage(string $threshold): string
+    {
+        return str_replace('{threshold}', $threshold, self::MSG);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
+        ],
+        "test:coverage:xml": [
+            "phpunit --coverage-xml ./coverage"
         ]
     },
     "extra": {


### PR DESCRIPTION
Resolves #18.

Adds a Github action (defined in laravel.yml) to run our phpunit test suite, generate a code coverage report in XML format, and then run our custom artisan command to compare the code coverage against a set threshold (currently set at 60%).

We can adjust this going forward. Actually we'll want to move that out of the YAML file into a repository variable, I'll create a ticket for that.